### PR TITLE
Katana change

### DIFF
--- a/src/main/java/draylar/gateofbabylon/enchantment/KatanaSlashEnchantment.java
+++ b/src/main/java/draylar/gateofbabylon/enchantment/KatanaSlashEnchantment.java
@@ -15,7 +15,7 @@ public class KatanaSlashEnchantment extends Enchantment implements ValidatingEnc
 
     private final SoundEvent sound;
     private final ParticleEffect particle;
-    private final HitExecutor onHit;
+    protected final HitExecutor onHit;
 
     public KatanaSlashEnchantment(SoundEvent sound, ParticleEffect particle) {
         this(sound, particle, (entity, player, stack) -> {});

--- a/src/main/java/draylar/gateofbabylon/enchantment/ThunderSlashEnchantment.java
+++ b/src/main/java/draylar/gateofbabylon/enchantment/ThunderSlashEnchantment.java
@@ -1,0 +1,27 @@
+package draylar.gateofbabylon.enchantment;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LightningEntity;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+
+public class ThunderSlashEnchantment extends KatanaSlashEnchantment {
+    
+    public ThunderSlashEnchantment() {
+        super(SoundEvents.ENTITY_LIGHTNING_BOLT_THUNDER, ParticleTypes.CLOUD, (target, source, stack) -> {
+            if (target.world instanceof ServerWorld && target.world.isThundering()) {
+                BlockPos blockPos = target.getBlockPos();
+                if (target.world.isSkyVisible(blockPos)) {
+                    LightningEntity lightningEntity = (LightningEntity)EntityType.LIGHTNING_BOLT.create(target.world);
+                    lightningEntity.refreshPositionAfterTeleport(Vec3d.ofBottomCenter(blockPos));
+                    lightningEntity.setChanneler(source instanceof ServerPlayerEntity ? (ServerPlayerEntity)source : null);
+                    target.world.spawnEntity(lightningEntity);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/draylar/gateofbabylon/item/KatanaItem.java
+++ b/src/main/java/draylar/gateofbabylon/item/KatanaItem.java
@@ -8,7 +8,8 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.mob.HostileEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.TameableEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -104,17 +105,19 @@ public class KatanaItem extends SwordItem {
                         }
 
                         // check for small box around the current position for enemies
-                        world.getEntitiesByClass(HostileEntity.class, new Box(currentPos.add(-2, -2, -2), currentPos.add(2, 2, 2)), entity -> !hitEntities.contains(entity.getUuid())).forEach(entity -> {
-                            entity.damage(DamageSource.player((PlayerEntity) user), getAttackDamage() / 2);
+                        world.getEntitiesByClass(MobEntity.class, new Box(currentPos.add(-2, -2, -2), currentPos.add(2, 2, 2)), entity -> !hitEntities.contains(entity.getUuid())).forEach(entity -> {
+                            if (!(entity instanceof TameableEntity) || !((TameableEntity) entity).isTamed() || !((TameableEntity) entity).getOwnerUuid().equals(player.getUuid())) {
+                                entity.damage(DamageSource.player((PlayerEntity) user), getAttackDamage() / 2);
 
-                            if(enchantment != null) {
-                                enchantment.onHit(entity, player, stack);
+                                if(enchantment != null) {
+                                    enchantment.onHit(entity, player, stack);
+                                }
+
+                                world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), GOBSounds.KATANA_SWOOP, SoundCategory.PLAYERS, 2F, 1.5F + (float) world.random.nextDouble() * .5f);
+                                world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.PLAYERS, 0.5F, 1.5F + (float) world.random.nextDouble() * .5f);
+                                serverWorld.spawnParticles(ParticleTypes.PORTAL, entity.getX(), entity.getY() + .5, entity.getZ(), 25, 0, 0, 0, .1);
+                                hitEntities.add(entity.getUuid());
                             }
-
-                            world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), GOBSounds.KATANA_SWOOP, SoundCategory.PLAYERS, 2F, 1.5F + (float) world.random.nextDouble() * .5f);
-                            world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.PLAYERS, 0.5F, 1.5F + (float) world.random.nextDouble() * .5f);
-                            serverWorld.spawnParticles(ParticleTypes.PORTAL, entity.getX(), entity.getY() + .5, entity.getZ(), 25, 0, 0, 0, .1);
-                            hitEntities.add(entity.getUuid());
                         });
                     }
 

--- a/src/main/java/draylar/gateofbabylon/registry/GOBEnchantments.java
+++ b/src/main/java/draylar/gateofbabylon/registry/GOBEnchantments.java
@@ -2,6 +2,7 @@ package draylar.gateofbabylon.registry;
 
 import draylar.gateofbabylon.GateOfBabylon;
 import draylar.gateofbabylon.enchantment.KatanaSlashEnchantment;
+import draylar.gateofbabylon.enchantment.ThunderSlashEnchantment;
 import draylar.gateofbabylon.enchantment.LungingEnchantment;
 import draylar.gateofbabylon.enchantment.QuickDrawEnchantment;
 import draylar.gateofbabylon.enchantment.SmashingEnchantment;
@@ -15,7 +16,7 @@ public class GOBEnchantments {
     public static final LungingEnchantment LUNGING = register("lunging", new LungingEnchantment());
     public static final SmashingEnchantment SMASHING = register("smashing", new SmashingEnchantment());
     public static final KatanaSlashEnchantment GOD_SLASH = register("god_slash", new KatanaSlashEnchantment(SoundEvents.ENTITY_ENDER_DRAGON_AMBIENT, ParticleTypes.WITCH));
-    public static final KatanaSlashEnchantment THUNDER_SLASH = register("thunder_slash", new KatanaSlashEnchantment(SoundEvents.ENTITY_LIGHTNING_BOLT_THUNDER, ParticleTypes.CLOUD));
+    public static final ThunderSlashEnchantment THUNDER_SLASH = register("thunder_slash", new ThunderSlashEnchantment());
     public static final KatanaSlashEnchantment FLAME_SLASH = register("flame_slash", new KatanaSlashEnchantment(SoundEvents.BLOCK_FIRE_AMBIENT, ParticleTypes.FLAME, (target, source, stack) -> target.setOnFireFor(5)));
     public static final QuickDrawEnchantment QUICKDRAW = register("quickdraw", new QuickDrawEnchantment());
 


### PR DESCRIPTION
- Added lightning summoning effect to thunder slash, only works during storms similar to channeling enchantment on tridents.
- Changed katana slash to affect all mobs except for those tamed by the user.