### PR TITLE
Prevent unnecessary spawn of FallingBlockEntities

### DIFF
--- a/src/main/java/draylar/gateofbabylon/item/WaraxeItem.java
+++ b/src/main/java/draylar/gateofbabylon/item/WaraxeItem.java
@@ -66,7 +66,7 @@ public class WaraxeItem extends AxeItem implements EnchantmentHandler {
                             level++;
                         }
 
-                        if(world.getBlockState(new BlockPos(newPos).up()).isAir()) {
+                        if(world.getBlockState(new BlockPos(newPos).up()).isAir() && !world.getBlockState(new BlockPos(newPos)).isAir()) {
                             spawnEntity((ServerWorld) world, newPos.add(0, 1, 0), user, world.getBlockState(new BlockPos(newPos)));
                         }
                     }


### PR DESCRIPTION
Add a check for if position for spawning FallingBlockEntity for WaraxeItem's shockwave ability is not air to prevent spawning an Entity that is discarded in the next tick.